### PR TITLE
Add very basic spec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,8 @@ lazy val core = module("be-kind-rewind", Some("core"))
     fork := true,
     baseDirectory in run := file("."),
     libraryDependencies ++= Seq(
+      "dev.zio"  %% "zio-test"     % Version.ziotest % "test",
+      "dev.zio"  %% "zio-test-sbt" % Version.ziotest % "test",
       "io.circe" %% "circe-core"   % Version.circe,
       "io.circe" %% "circe-parser" % Version.circe
     )

--- a/build.sbt
+++ b/build.sbt
@@ -36,10 +36,9 @@ lazy val core = module("be-kind-rewind", Some("core"))
     fork := true,
     baseDirectory in run := file("."),
     libraryDependencies ++= Seq(
-      "dev.zio"  %% "zio-test"     % Version.ziotest % "test",
-      "dev.zio"  %% "zio-test-sbt" % Version.ziotest % "test",
-      "io.circe" %% "circe-core"   % Version.circe,
-      "io.circe" %% "circe-parser" % Version.circe
+      "org.scalameta" %% "munit"        % Version.munit % Test,
+      "io.circe"      %% "circe-core"   % Version.circe,
+      "io.circe"      %% "circe-parser" % Version.circe
     )
   )
 

--- a/core/src/test/scala/bekindrewind/VcrClientSpec.scala
+++ b/core/src/test/scala/bekindrewind/VcrClientSpec.scala
@@ -1,7 +1,6 @@
 package bekindrewind
 
-import zio.test._
-import zio.test.Assertion._
+import munit._
 import io.circe.parser._
 import io.circe.syntax._
 
@@ -10,45 +9,55 @@ import java.nio.file._
 import java.time.OffsetDateTime
 import scala.jdk.CollectionConverters._
 
-object VcrClientSpec extends DefaultRunnableSpec {
-  def spec = suite("VcrClientSpec")(
-    test("Request and response are saved as JSON") {
-      val recordingPath = Files.createTempFile("test", ".json")
-      val client        = MockClient(recordingPath, RecordOptions.default, VcrMatcher(_ => true))
-      val record        = VcrRecord(
-        VcrRecordRequest("GET", new URI("https://example.com/foo.json"), "{}", Map.empty),
-        VcrRecordResponse(200, "ok", Map.empty, "{}"),
-        OffsetDateTime.parse("2100-05-06T12:34:56.789Z")
-      )
-      client.newlyRecorded.set(Vector(record))
-      client.save()
+class VcrClientSpec extends FunSuite {
 
-      val savedJson = Files.readAllLines(recordingPath).asScala.mkString("")
-      val decoded   = decode[VcrRecords](savedJson).map(_.records)
-      assert(decoded)(equalTo(Right(Vector(record))))
-    },
-    test("Client loads the previous record when being constructed") {
-      val req     = VcrRecordRequest("GET", new URI("https://example.com/foo.json"), "{}", Map.empty)
-      val res     = VcrRecordResponse(200, "ok", Map.empty, "{}")
-      val at      = OffsetDateTime.parse("2100-05-06T12:34:56.789Z")
-      val rawJson = s"""{ "version": "0.1.0",
-                       |  "records": [
-                       |    { "request": ${req.asJson},
-                       |      "response": ${res.asJson},
-                       |      "recordedAt": ${at.asJson}
-                       |    }
-                       |  ]
-                       |}""".stripMargin
+  test("Request and response are saved as JSON") {
+    val recordingPath = Files.createTempFile("test", ".json")
+    val client        = MockClient(recordingPath, RecordOptions.default, VcrMatcher(_ => true))
+    assert(client.previouslyRecorded.isEmpty)
+    assert(client.newlyRecorded.get().isEmpty)
 
-      val recordingPath = Files.createTempFile("test", ".json")
-      Files.write(recordingPath, Seq(rawJson).asJava)
+    val record = VcrRecord(
+      VcrRecordRequest("GET", new URI("https://example.com/foo.json"), "{}", Map.empty),
+      VcrRecordResponse(200, "ok", Map.empty, "{}"),
+      OffsetDateTime.parse("2100-05-06T12:34:56.789Z")
+    )
+    client.newlyRecorded.set(Vector(record))
+    client.save()
+    assert(client.previouslyRecorded.isEmpty)
+    assert(client.newlyRecorded.get().sizeIs == 1)
 
-      val client               = MockClient(recordingPath, RecordOptions.default, VcrMatcher(_ => true))
-      val maybeStatefulRecords = client.previouslyRecorded.get(true)
-      assert(maybeStatefulRecords.map(_.records))(equalTo(Some(Vector(VcrRecord(req, res, at))))) &&
-      assert(maybeStatefulRecords.map(_.currentIndex.get()))(equalTo(Some(0)))
+    val savedJson = Files.readAllLines(recordingPath).asScala.mkString("")
+    val decoded   = decode[VcrRecords](savedJson).map(_.records)
+    assertEquals(decoded, Right(Vector(record)))
+  }
+
+  test("Client loads the previous record when being constructed") {
+    val req     = VcrRecordRequest("GET", new URI("https://example.com/foo.json"), "{}", Map.empty)
+    val res     = VcrRecordResponse(200, "ok", Map.empty, "{}")
+    val at      = OffsetDateTime.parse("2100-05-06T12:34:56.789Z")
+    val rawJson = s"""{ "version": "0.1.0",
+                     |  "records": [
+                     |    { "request": ${req.asJson},
+                     |      "response": ${res.asJson},
+                     |      "recordedAt": ${at.asJson}
+                     |    }
+                     |  ]
+                     |}""".stripMargin
+
+    val recordingPath = Files.createTempFile("test", ".json")
+    Files.write(recordingPath, Seq(rawJson).asJava)
+
+    val client = MockClient(recordingPath, RecordOptions.default, VcrMatcher(_ => true))
+    assert(client.newlyRecorded.get().isEmpty)
+    client.previouslyRecorded.get(true) match {
+      case None           => fail("Should load the record !!")
+      case Some(previous) =>
+        assertEquals(previous.records, Vector(VcrRecord(req, res, at)))
+        assertEquals(previous.currentIndex.get(), 0)
     }
-  )
+  }
+
 }
 
 case class MockClient(recordingPath: Path, recordOptions: RecordOptions, matcher: VcrMatcher) extends VcrClient

--- a/core/src/test/scala/bekindrewind/VcrClientSpec.scala
+++ b/core/src/test/scala/bekindrewind/VcrClientSpec.scala
@@ -1,0 +1,54 @@
+package bekindrewind
+
+import zio.test._
+import zio.test.Assertion._
+import io.circe.parser._
+import io.circe.syntax._
+
+import java.net.URI
+import java.nio.file._
+import java.time.OffsetDateTime
+import scala.jdk.CollectionConverters._
+
+object VcrClientSpec extends DefaultRunnableSpec {
+  def spec = suite("VcrClientSpec")(
+    test("Request and response are saved as JSON") {
+      val recordingPath = Files.createTempFile("test", ".json")
+      val client        = MockClient(recordingPath, RecordOptions.default, VcrMatcher(_ => true))
+      val record        = VcrRecord(
+        VcrRecordRequest("GET", new URI("https://example.com/foo.json"), "{}", Map.empty),
+        VcrRecordResponse(200, "ok", Map.empty, "{}"),
+        OffsetDateTime.parse("2100-05-06T12:34:56.789Z")
+      )
+      client.newlyRecorded.set(Vector(record))
+      client.save()
+
+      val savedJson = Files.readAllLines(recordingPath).asScala.mkString("")
+      val decoded   = decode[VcrRecords](savedJson).map(_.records)
+      assert(decoded)(equalTo(Right(Vector(record))))
+    },
+    test("Client loads the previous record when being constructed") {
+      val req     = VcrRecordRequest("GET", new URI("https://example.com/foo.json"), "{}", Map.empty)
+      val res     = VcrRecordResponse(200, "ok", Map.empty, "{}")
+      val at      = OffsetDateTime.parse("2100-05-06T12:34:56.789Z")
+      val rawJson = s"""{ "version": "0.1.0",
+                       |  "records": [
+                       |    { "request": ${req.asJson},
+                       |      "response": ${res.asJson},
+                       |      "recordedAt": ${at.asJson}
+                       |    }
+                       |  ]
+                       |}""".stripMargin
+
+      val recordingPath = Files.createTempFile("test", ".json")
+      Files.write(recordingPath, Seq(rawJson).asJava)
+
+      val client               = MockClient(recordingPath, RecordOptions.default, VcrMatcher(_ => true))
+      val maybeStatefulRecords = client.previouslyRecorded.get(true)
+      assert(maybeStatefulRecords.map(_.records))(equalTo(Some(Vector(VcrRecord(req, res, at))))) &&
+      assert(maybeStatefulRecords.map(_.currentIndex.get()))(equalTo(Some(0)))
+    }
+  )
+}
+
+case class MockClient(recordingPath: Path, recordOptions: RecordOptions, matcher: VcrMatcher) extends VcrClient

--- a/core/src/test/scala/bekindrewind/VcrClientSpec.scala
+++ b/core/src/test/scala/bekindrewind/VcrClientSpec.scala
@@ -7,7 +7,6 @@ import io.circe.syntax._
 import java.net.URI
 import java.nio.file._
 import java.time.OffsetDateTime
-import scala.jdk.CollectionConverters._
 
 class VcrClientSpec extends FunSuite {
 
@@ -27,7 +26,7 @@ class VcrClientSpec extends FunSuite {
     assert(client.previouslyRecorded.isEmpty)
     assert(client.newlyRecorded.get().sizeIs == 1)
 
-    val savedJson = Files.readAllLines(recordingPath).asScala.mkString("")
+    val savedJson = Files.readString(recordingPath)
     val decoded   = decode[VcrRecords](savedJson).map(_.records)
     assertEquals(decoded, Right(Vector(record)))
   }
@@ -46,7 +45,7 @@ class VcrClientSpec extends FunSuite {
                      |}""".stripMargin
 
     val recordingPath = Files.createTempFile("test", ".json")
-    Files.write(recordingPath, Seq(rawJson).asJava)
+    Files.writeString(recordingPath, rawJson)
 
     val client = MockClient(recordingPath, RecordOptions.default, VcrMatcher(_ => true))
     assert(client.newlyRecorded.get().isEmpty)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,8 +8,9 @@ object Build {
   val BeKindRewindVersion = "0.1.0"
 
   object Version {
-    val circe = "0.13.0"
-    val sttp  = "3.2.0"
+    val circe   = "0.13.0"
+    val sttp    = "3.2.0"
+    val ziotest = "1.0.5"
   }
 
   lazy val ScalacOptions = Seq(
@@ -52,6 +53,7 @@ object Build {
       incOptions ~= (_.withLogRecompileOnMacro(false)),
       autoAPIMappings := true,
       resolvers := Resolvers,
+      testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
       fork in Test := true,
       logBuffered in Test := false
     )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,9 +8,9 @@ object Build {
   val BeKindRewindVersion = "0.1.0"
 
   object Version {
-    val circe   = "0.13.0"
-    val sttp    = "3.2.0"
-    val ziotest = "1.0.5"
+    val circe = "0.13.0"
+    val sttp  = "3.2.0"
+    val munit = "0.7.23"
   }
 
   lazy val ScalacOptions = Seq(
@@ -53,7 +53,7 @@ object Build {
       incOptions ~= (_.withLogRecompileOnMacro(false)),
       autoAPIMappings := true,
       resolvers := Resolvers,
-      testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
+      testFrameworks := Seq(new TestFramework("munit.Framework")),
       fork in Test := true,
       logBuffered in Test := false
     )


### PR DESCRIPTION
I would like to add more HTTP clients support.
Before adding more, I thinks test framework should be enabled so new client supports are verified unbroken.

* Set up MUnit
* Added very basic tests for `save()` and ***load*** on construction

