### PR TITLE
Expiration support

### DIFF
--- a/core/src/main/scala/bekindrewind/RecordOptions.scala
+++ b/core/src/main/scala/bekindrewind/RecordOptions.scala
@@ -1,9 +1,12 @@
 package bekindrewind
 
+import scala.concurrent.duration.FiniteDuration
+
 final case class RecordOptions(
   shouldRecord: VcrRecordRequest => Boolean,
   notRecordedThrowsErrors: Boolean,
   overwriteAll: Boolean,
+  expiresAfter: Option[FiniteDuration],
   recordTransformer: RecordTransformer
 ) {
   def shouldRecord(shouldRecord: VcrRecordRequest => Boolean): RecordOptions =
@@ -21,6 +24,7 @@ object RecordOptions {
     _ => true,
     notRecordedThrowsErrors = false,
     overwriteAll = false,
+    expiresAfter = None,
     recordTransformer = identity
   )
 
@@ -28,6 +32,7 @@ object RecordOptions {
     _ => false,
     notRecordedThrowsErrors = false,
     overwriteAll = false,
+    expiresAfter = None,
     recordTransformer = identity
   )
 }

--- a/core/src/main/scala/bekindrewind/RecordOptions.scala
+++ b/core/src/main/scala/bekindrewind/RecordOptions.scala
@@ -1,11 +1,11 @@
 package bekindrewind
 
-import scala.concurrent.duration.FiniteDuration
+import java.time.Duration
 
 final case class RecordOptions(
   notRecordedThrowsErrors: Boolean,
   overwriteAll: Boolean,
-  expiresAfter: Option[FiniteDuration]
+  expiresAfter: Option[Duration]
 ) {
   def notRecordedThrowsErrors(notRecordedThrowsErrors: Boolean): RecordOptions =
     copy(notRecordedThrowsErrors = notRecordedThrowsErrors)

--- a/core/src/main/scala/bekindrewind/VcrClient.scala
+++ b/core/src/main/scala/bekindrewind/VcrClient.scala
@@ -59,7 +59,7 @@ trait VcrClient {
     val newRecords      = newlyRecordedRef.get
     val allRecords      = previousRecords ++ newRecords
 
-    val expiration = recordOptions.expiresAfter.map(duration => OffsetDateTime.now().plusNanos(duration.toNanos))
+    val expiration = recordOptions.expiresAfter.map(duration => OffsetDateTime.now().plus(duration))
 
     println(s"Writing ${allRecords.size} records to ${recordingPath.toAbsolutePath}")
     expiration.foreach(datetime => println(s"It will expire after $datetime"))

--- a/core/src/main/scala/bekindrewind/VcrClient.scala
+++ b/core/src/main/scala/bekindrewind/VcrClient.scala
@@ -60,11 +60,14 @@ trait VcrClient {
     val newRecords      = newlyRecordedRef.get
     val allRecords      = previousRecords ++ newRecords
 
+    val expiration = recordOptions.expiresAfter.map(duration => OffsetDateTime.now().plusNanos(duration.toNanos))
+
     println(s"Writing ${allRecords.size} records to ${recordingPath.toAbsolutePath}")
+    expiration.foreach(datetime => println(s"It will expire after $datetime"))
 
     VcrIO.write(
       recordingPath,
-      VcrRecords(allRecords, BuildInfo.version)
+      VcrRecords(allRecords, BuildInfo.version, expiration)
     )
   }
 

--- a/core/src/main/scala/bekindrewind/VcrRecord.scala
+++ b/core/src/main/scala/bekindrewind/VcrRecord.scala
@@ -52,13 +52,13 @@ object VcrRecordResponse {
     Decoder.forProduct5("statusCode", "statusText", "headers", "body", "contentType")(VcrRecordResponse.apply)
 }
 
-final case class VcrRecords(records: Vector[VcrRecord], version: String)
+final case class VcrRecords(records: Vector[VcrRecord], version: String, expiration: Option[OffsetDateTime] = None)
 
 object VcrRecords {
   implicit val encoder: Encoder[VcrRecords] =
-    Encoder.forProduct2("records", "version")(o => (o.records, o.version))
+    Encoder.forProduct3("records", "version", "expiration")(o => (o.records, o.version, o.expiration))
 
-  implicit val decoder: Decoder[VcrRecords] = Decoder.forProduct2("records", "version")(VcrRecords.apply)
+  implicit val decoder: Decoder[VcrRecords] = Decoder.forProduct3("records", "version", "expiration")(VcrRecords.apply)
 }
 
 final case class StatefulVcrRecords(records: Vector[VcrRecord], currentIndex: AtomicInteger) {

--- a/core/src/test/scala/bekindrewind/VcrClientSpec.scala
+++ b/core/src/test/scala/bekindrewind/VcrClientSpec.scala
@@ -7,7 +7,7 @@ import munit._
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file._
-import java.time.OffsetDateTime
+import java.time.{ Duration, OffsetDateTime }
 
 class VcrClientSpec extends FunSuite {
 
@@ -88,12 +88,11 @@ class VcrClientSpec extends FunSuite {
   }
 
   test("Record file should have expiration field if option specified") {
-    import scala.concurrent.duration._
     val recordingPath = Files.createTempFile("test", ".json")
     val client        = MockClient(
       recordingPath,
       RecordOptions.default.copy(
-        expiresAfter = Some(90 days)
+        expiresAfter = Some(Duration.ofDays(90))
       ),
       VcrMatcher.identity
     )

--- a/core/src/test/scala/bekindrewind/VcrClientSpec.scala
+++ b/core/src/test/scala/bekindrewind/VcrClientSpec.scala
@@ -95,7 +95,7 @@ class VcrClientSpec extends FunSuite {
       RecordOptions.default.copy(
         expiresAfter = Some(90 days)
       ),
-      VcrMatcher(_ => true)
+      VcrMatcher.identity
     )
     assert(client.previouslyRecorded.isEmpty)
     assert(client.newlyRecorded().isEmpty)
@@ -129,9 +129,9 @@ class VcrClientSpec extends FunSuite {
     val recordingPath = Files.createTempFile("test", ".json")
     Files.write(recordingPath, rawJson.getBytes(StandardCharsets.UTF_8))
 
-    val client = MockClient(recordingPath, RecordOptions.default, VcrMatcher(_ => true))
+    val client = MockClient(recordingPath, RecordOptions.default, VcrMatcher.groupBy(_ => "bucket"))
     assert(client.newlyRecorded().isEmpty)
-    assertEquals(client.previouslyRecorded.get(true), None)
+    assertEquals(client.previouslyRecorded.get(VcrKey("bucket")), None)
   }
 }
 


### PR DESCRIPTION
Closes #5

* `RecordOptions` now have `expiresAfter: Option[java.time.Duration]`: an option to say "expire the recordings after X days/duration" 
* `VcrRecords` now have `expiration: Option[OffsetDateTime]`
    * which is calculated "the datetime of saving file + `expiresAfter` duration"
    * `VcrClient` ignores a previous record file if it is expired. 