### PR TITLE
Setup CI matrix properly

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -12,13 +12,15 @@ jobs:
       fail-fast: false
       matrix:
         scala: [2.13.5, 2.12.13]
-        java: [11, 8]
+        java: [adopt@1.11, adopt@1.8]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
       - name: Set up environment
         uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ matrix.java }}
 
       - name: Run tests
-        run: sbt -Dscalac.unused.enabled=true fmtCheck test
+        run: sbt ++${{ matrix.scala}}  -Dscalac.unused.enabled=true fmtCheck test

--- a/core/src/test/scala/bekindrewind/VcrClientSpec.scala
+++ b/core/src/test/scala/bekindrewind/VcrClientSpec.scala
@@ -7,7 +7,7 @@ import munit._
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file._
-import java.time.{Duration, OffsetDateTime}
+import java.time.{ Duration, OffsetDateTime }
 import scala.collection.immutable
 
 class VcrClientSpec extends FunSuite {

--- a/core/src/test/scala/bekindrewind/VcrClientSpec.scala
+++ b/core/src/test/scala/bekindrewind/VcrClientSpec.scala
@@ -7,7 +7,8 @@ import munit._
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file._
-import java.time.{ Duration, OffsetDateTime }
+import java.time.{Duration, OffsetDateTime}
+import scala.collection.immutable
 
 class VcrClientSpec extends FunSuite {
 
@@ -40,7 +41,7 @@ class VcrClientSpec extends FunSuite {
       VcrMatcher.identity.withTransformer { case entry @ VcrEntry(req, res, _) =>
         entry.copy(
           request = req.copy(uri = new URI("https://example.com/SAFE")),
-          response = res.copy(headers = res.headers.removed("SENSITIVE_DATA"))
+          response = res.copy(headers = res.headers - "SENSITIVE_DATA")
         )
       }
     )
@@ -57,7 +58,7 @@ class VcrClientSpec extends FunSuite {
       VcrResponse(200, "ok", Map.empty, "{}", Some("text/json")),
       OffsetDateTime.parse("2100-05-06T12:34:56.789Z")
     )
-    assertEquals(client.newlyRecorded(), Seq(expected))
+    assertEquals(client.newlyRecorded(), immutable.Seq(expected))
 
     client.save()
     val savedJson = new String(Files.readAllBytes(recordingPath), StandardCharsets.UTF_8)


### PR DESCRIPTION
This PR fixes CI matrix so JDK 11 and Scala 2.12 are used. 