### PR TITLE
Drop Java 8 and add Java 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 on:
   push:
-    branches: [master, main]
-    tags: ["*"]
+    branches: [ master, main ]
+    tags: [ "*" ]
 jobs:
   publish:
     runs-on: ubuntu-20.04

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: [2.13.10, 2.12.17]
-        java: [adopt@1.11, adopt@1.8]
+        scala: [ 2.13.10, 2.12.17 ]
+        java: [ openjdk@1.11.0, openjdk@1.17.0 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -23,4 +23,4 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Run tests
-        run: sbt ++${{ matrix.scala}}  -Dscalac.unused.enabled=true fmtCheck test
+        run: sbt ++${{ matrix.scala }}  -Dscalac.unused.enabled=true fmtCheck test


### PR DESCRIPTION
Main motivation is sttp-client [dropping Java 8 support](https://github.com/softwaremill/sttp/releases/tag/v3.6.1). This will pave the way for #160.
Another way forward is to keep Java 8 support for all modules except for client-sttp, though maybe in another PR if there's demand for it?